### PR TITLE
Strike status field from template and existing RFCs

### DIFF
--- a/accepted/0002-view_api/README.md
+++ b/accepted/0002-view_api/README.md
@@ -1,6 +1,8 @@
 ---
-author: Roni Choudhury
-date: 2020-06-11
+RFC: 0002
+Author: Roni Choudhury
+Created: 2020-06-11
+Last-Modified: 2020-06-11
 ---
 
 # RFC: AQL-Based Table Creation

--- a/accepted/0005-permissions_model/README.md
+++ b/accepted/0005-permissions_model/README.md
@@ -1,7 +1,6 @@
 ---
 RFC: 0005
 Author: Roni Choudhury
-Status: accepted
 Created: 2020-05-22
 Last-Modified: 2020-07-15
 ---

--- a/accepted/0006-orm/README.md
+++ b/accepted/0006-orm/README.md
@@ -1,7 +1,6 @@
 ---
 RFC: 0006
 Author: Jacob Nesbitt
-Status: draft
 Created: 2020-07-28
 Last-Modified: 2020-07-30
 ---

--- a/accepted/0007-multinetjs-autopublish/README.md
+++ b/accepted/0007-multinetjs-autopublish/README.md
@@ -1,7 +1,6 @@
 ---
 RFC: 0007
 Author: Roni Choudhury
-Status: draft
 Created: 2020-07-09
 Last-Modified: 2020-07-09
 ---

--- a/final/0003-rfc_process/README.md
+++ b/final/0003-rfc_process/README.md
@@ -1,7 +1,6 @@
 ---
 RFC: 0003
 Author: Roni Choudhury
-Status: final
 Created: 2020-06-29
 Last-Modified: 2020-07-17
 Supersedes: 0001

--- a/superseded/0001-rfcs/README.md
+++ b/superseded/0001-rfcs/README.md
@@ -1,7 +1,6 @@
 ---
 RFC: 0001
 Author: Roni Choudhury
-Status: superseded
 Created: 2020-06-10
 Last-Modified: 2020-06-10
 Superseded-By: 0003

--- a/template.md
+++ b/template.md
@@ -1,7 +1,6 @@
 ---
 RFC: XXXX
 Author: John Q. Public
-Status: draft
 Created: 2020-06-29
 Last-Modified: 2020-06-29
 Supersedes: XXXX (not usually required)

--- a/withdrawn/0004-upload-system/README.md
+++ b/withdrawn/0004-upload-system/README.md
@@ -1,7 +1,6 @@
 ---
 RFC: 0004
 Author: Jacob Nesbitt
-Status: withdrawn
 Created: 2020-07-08
 Last-Modified: 2020-07-08
 ---


### PR DESCRIPTION
Do you think we need this field in the RFCs themselves? It seems like moving the files between directories is enough. What do people think?